### PR TITLE
🎨 support config mail domain setting

### DIFF
--- a/app/components/gh-members-lab-setting.js
+++ b/app/components/gh-members-lab-setting.js
@@ -14,6 +14,8 @@ export default Component.extend({
 
     defaultContentVisibility: reads('settings.defaultContentVisibility'),
 
+    mailDomain: computed.or('config.mail.domain', 'blogDomain'),
+
     mailgunRegion: computed('settings.bulkEmailSettings.baseUrl', function () {
         if (!this.settings.get('bulkEmailSettings.baseUrl')) {
             return US;

--- a/app/templates/components/gh-members-lab-setting.hbs
+++ b/app/templates/components/gh-members-lab-setting.hbs
@@ -178,7 +178,7 @@
                         @input={{action "setSubscriptionSettings" "fromAddress"}}
                         @class="w20"
                     />
-                    <span class="gh-input-append"> @{{this.blogDomain}}</span>
+                    <span class="gh-input-append"> @{{mailDomain}} </span>
                 </div>
                 <div class="f8 fw4 midgrey mt1">Your members will receive system emails from this address</div>
             </GhFormGroup>


### PR DESCRIPTION
closes #11414

- This enabled support for PR email-config-domain in Ghost repository.

- members settings changes from blog domain to config mail setting

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
